### PR TITLE
fix: Removed conflicting meta description tags on feature guide pages  

### DIFF
--- a/themes/hugo-theme-ephemeralenvironments/layouts/partials/meta.html
+++ b/themes/hugo-theme-ephemeralenvironments/layouts/partials/meta.html
@@ -3,7 +3,6 @@
 <meta name="twitter:site" value="@ephemeralenvs"/>
 <meta property="twitter:creator" content="@shipyardbuild"/>
 <meta name="twitter:card" content="{{ .Site.BaseURL }}/images/ephemeralenvironments-preview.png">
-<meta name="og:description" content="Learn how ephemeral environments can help you and your team">
 <meta property="og:image" content="{{ .Site.BaseURL }}/images/ephemeralenvironments-preview.png" itemprop="image" />
 <meta property="og:title" content="{{ with .Params.pagetitle }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}"/>
 {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}


### PR DESCRIPTION
**Description**
Removed conflicting meta description tag in Partials/meta.html which was rendering the extra description across all feature pages

**Issue**
Closes #43 