### PR TITLE
Feature:  Add new contributor page with Github usernames

### DIFF
--- a/content/about/contributors.md
+++ b/content/about/contributors.md
@@ -1,0 +1,16 @@
++++
+date = "2021-08-13T00:00:00Z"
+title = "Ephemeral Environments Contributors"
+featuresslug = "contributors"
+type = "about"
+hero = "https://octodex.github.com/images/surftocat.png"
+metadescription = "Contributors to Ephemeral Environments"
+pagetitle = "Ephemeral Environments Across Contributors"
+ogimage = "https://octodex.github.com/images/surftocat.png"
++++
+
+**The team at [Shipyard](https://shipyard.build/) provides the guides for [Ephemeral Environments.io](https://ephemeralenvironments.io/). In the spirit of accountability and fostering communication, this information has been made open source for the community. These are are individuals who have contributed in improving Ephemeral Environment documentation.**
+
+{{< contributors username="nbeck415" >}}
+{{< contributors username="bueller" >}}
+{{< contributors username="creaturenex" >}}

--- a/themes/hugo-theme-ephemeralenvironments/layouts/about/single.html
+++ b/themes/hugo-theme-ephemeralenvironments/layouts/about/single.html
@@ -1,0 +1,25 @@
+{{ partial "header.html" . }}
+
+<div class="second-nav">
+  <div class="container" id="breadcrumbs">
+    <div id="tool-tip">
+      <span style="cursor:pointer;color:#878787">TEST - Github?</span>
+      <div class="tool-tip">
+        <ul>
+          <li><a href="https://github.com/ephemeralenvironments/ephemeralenvironments">Star</a></li>
+          <hr />
+          <li><a href="https://github.com/ephemeralenvironments/ephemeralenvironments/fork">Fork</a></li>
+          <hr />
+          <li><a href="https://github.com/ephemeralenvironments/ephemeralenvironments/subscription">Watch</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container" id="article">
+  <h1>{{.Title}}</h1>
+  <p align="center"><img src="{{ .Params.hero }}" alt="{{ .Params.title }}" width="200" height="200" />TEST IMAGE</p>
+
+  {{ .Content }}
+  {{ partial "footer.html" . }}

--- a/themes/hugo-theme-ephemeralenvironments/layouts/partials/footer.html
+++ b/themes/hugo-theme-ephemeralenvironments/layouts/partials/footer.html
@@ -8,21 +8,32 @@
     <div class="container" id="footer">
         <p class="contributed-footer" align="center">
             <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank">
-            <img alt="Creative Commons License" class="cc-image" style="border-width:0; height:35px;" src="/images/by-nc-sa.png" alt="CC license BY NC SA"/>
-            </a>Contributed by <a class="shipyard-logo" href="https://www.shipyard.build" target="_blank" alt="Shipyard logo white"></a></p>
-
-            <div align="center" style="padding-top: 10px; padding-bottom: 10px;">
-                <a class="github-button" href="https://github.com/ephemeralenvironments/ephemeralenvironments" data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-icon="octicon-star" data-size="large" aria-label="Star ephemeralenvironments/ephemeralenvironments on GitHub" target="_blank">Star</a>
-                <a class="github-button" href="https://github.com/ephemeralenvironments/ephemeralenvironments/fork" data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork ephemeralenvironments/ephemeralenvironments on GitHub" target="_blank">Fork</a>
-                <a class="github-button" href="https://github.com/ephemeralenvironments/ephemeralenvironments/subscription" data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-icon="octicon-eye" data-size="large" aria-label="Watch ephemeralenvironments/ephemeralenvironments on GitHub" target="_blank">Watch</a>
-            </div>
-        <p align="center">Shipyard manages and creates ephemeral environments for you. <a href="https://shipyard.build/careers" target="_blank">We're hiring.</a></p>
-
+                <img alt="Creative Commons License" class="cc-image" style="border-width:0; height:35px;"
+                    src="/images/by-nc-sa.png" alt="CC license BY NC SA" />
+            </a>Contributed by <a class="shipyard-logo" href="https://www.shipyard.build" target="_blank"
+                alt="Shipyard logo white"></a>
+        </p>
+        <div align="center" style="padding-top: 10px; padding-bottom: 10px;">
+            <a class="github-button" href="https://github.com/ephemeralenvironments/ephemeralenvironments"
+                data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-icon="octicon-star"
+                data-size="large" aria-label="Star ephemeralenvironments/ephemeralenvironments on GitHub"
+                target="_blank">Star</a>
+            <a class="github-button" href="https://github.com/ephemeralenvironments/ephemeralenvironments/fork"
+                data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-icon="octicon-repo-forked"
+                data-size="large" aria-label="Fork ephemeralenvironments/ephemeralenvironments on GitHub"
+                target="_blank">Fork</a>
+            <a class="github-button" href="https://github.com/ephemeralenvironments/ephemeralenvironments/subscription"
+                data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-icon="octicon-eye"
+                data-size="large" aria-label="Watch ephemeralenvironments/ephemeralenvironments on GitHub"
+                target="_blank">Watch</a>
+        </div>
+        <div align="center" style="padding-top: 10px; padding-bottom: 10px;">
+            <a itemprop="url" href="/about/contributors">Contributors</a></li>
+        </div>
+        <p align="center">Shipyard manages and creates ephemeral environments for you. <a
+                href="https://shipyard.build/careers" target="_blank">We're hiring.</a></p>
     </div>
 </div>
-
-
-
 
 </body>
 


### PR DESCRIPTION
**Description**
Created a contributors page to acknowledge the open source community.

**Tasks**
- [x] Contributor page
- [ ] a YAML file with each contributor's name and GH username
- [ ] a Hugo HTML page/partial that uses a loop to populate all icons into the page
- [ ] maybe use similar format/system to the "Content Contributors" page, in that you're getting their GH icon

**Issue**
Closes #51 